### PR TITLE
Hyperlink DOI against preferred resolver

### DIFF
--- a/_research/_send-to-figshare.R
+++ b/_research/_send-to-figshare.R
@@ -6,7 +6,7 @@ id <- fs_new_article("Triglyceride Fatty Acid (TGFA) Composition Longitudinally 
           Full citation:
           ",
           type = "poster",
-          links = "http://dx.doi.org/10.2337/db16-1-381",
+          links = "https://doi.org/10.2337/db16-1-381",
           authors = c("Luke W. Johnston", "Stewart Harris", "Ravi Retnakaran",
                            "Bernard Zinman", "Zhen Liu", "Richard P. Bazinet",
                            "Anthony J. Hanley"),


### PR DESCRIPTION
The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) ;-)